### PR TITLE
expose with_handle, get_object

### DIFF
--- a/lib/data.ml
+++ b/lib/data.ml
@@ -1,10 +1,13 @@
 open Hdf5_caml
 open Hdf5_raw
 
-let in_dir =
-  let dir = Cmdargs.(get_string "-d" |> force ~usage:"-d [directory]") in
-  let dir = Fpath.(v dir) in
-  fun s -> Fpath.(dir / s) |> Fpath.to_string
+let in_dir s =
+  let dir =
+    lazy
+      (let dir = Cmdargs.(get_string "-d" |> force ~usage:"-d [directory]") in
+       Fpath.(v dir))
+  in
+  Fpath.(Lazy.force dir / s) |> Fpath.to_string
 
 
 let ensure_ext ext f = if Fpath.has_ext ext f then f else Fpath.add_ext ext f

--- a/lib/data.mli
+++ b/lib/data.mli
@@ -7,6 +7,8 @@ val in_dir : string -> string
 type h5
 
 val h5 : ?reuse:bool -> string -> h5
+val with_hand : h5 -> (Hdf5_caml.H5.t -> 'a) -> 'a
+val get_object : Hdf5_caml.H5.t -> string -> Hdf5_caml.H5.t * string
 
 module Iter : sig
   type index_order =

--- a/lib/data.mli
+++ b/lib/data.mli
@@ -7,7 +7,7 @@ val in_dir : string -> string
 type h5
 
 val h5 : ?reuse:bool -> string -> h5
-val with_hand : h5 -> (Hdf5_caml.H5.t -> 'a) -> 'a
+val with_handle : h5 -> (Hdf5_caml.H5.t -> 'a) -> 'a
 val get_object : Hdf5_caml.H5.t -> string -> Hdf5_caml.H5.t * string
 
 module Iter : sig
@@ -108,4 +108,4 @@ val bool : json:json -> string -> bool -> bool
 val int : json:json -> string -> int -> int
 val float : json:json -> string -> float -> float
 val string : json:json -> string -> string -> string
-val any : json:json -> string -> ('a -> Yojson.Safe.t) -> 'a -> 'a
+val any : json:json -> string -> ('a -> Yojson.Safe.json) -> 'a -> 'a


### PR DESCRIPTION
1. expose with_handle and get_object so that we can directly work on H5.t objects
2. no force usage of `in_dir` if it is not used in the script + lazy evaluation when it is used